### PR TITLE
Added "Licensing Page" Reflecting "MIT License"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -343,6 +343,12 @@ const config = {
                 label: "Cookie Policy",
                 to: "/cookie-policy",
               },
+
+              {
+                label: "Licensing",
+                to: "/License/",
+              },
+
             ],
           },
           {

--- a/src/pages/License/index.tsx
+++ b/src/pages/License/index.tsx
@@ -1,0 +1,106 @@
+import Layout from "@theme/Layout";
+import React from "react";
+
+import styled from "styled-components";
+
+const LicensingContainer = styled.div`
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+  border-radius: 5px;
+
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
+  margin-top: 20px;
+
+  margin-bottom: 20px;
+  font-size: 16px;
+  line-height: 1.6;
+  font-family: "Open Sans", sans-serif;
+  text-align: justify;
+`;
+
+
+const Title = styled.h2`
+    margin-bottom: 24px;
+
+    font-family: "Open Sans", sans-serif;
+    font-weight: 700;
+
+    line-height: 1.6;
+    text-align: center;
+    font-size : 27px;
+`;
+
+const SubTitle = styled.h3`
+  margin-bottom: 20px;
+  font-weight: 700;
+
+`;
+
+const Content = styled.p`
+  margin-bottom: 20px;
+
+`;
+
+const Licensing: React.FC = () => {
+  return (
+    <Layout
+
+      title={"Licensing"}
+      description="Licensing information for CodeHarborHub"
+
+    >
+      <LicensingContainer>
+
+        <Title>Licensing</Title>
+
+        Welcome to CodeHarborHub, This project is licensed under the MIT License. This page outlines the terms of the
+      license and provides details on how you can use, modify and distribute our project.
+
+        <Content>
+          <SubTitle>MIT License</SubTitle>
+          <Content>
+
+            <strong>Copyright (c) 2024 CodeHarborHub</strong>
+            <br />
+            <br />
+
+            Permission is hereby granted, free of charge, to any person obtaining a copy
+            of this software and associated documentation files (the "Software"), to deal
+            in the Software without restriction, including without limitation the rights
+            to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+            copies of the Software, and to permit persons to whom the Software is
+            furnished to do so, subject to the following conditions:
+
+            <br />
+            <br />
+
+            The above copyright notice and this permission notice shall be included in all
+            copies or substantial portions of the Software.
+            <br />
+            <br />
+
+            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+            FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+            AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+            LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+            OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+            SOFTWARE.
+            <br />
+            <br />
+          </Content>
+
+        </Content>
+      </LicensingContainer>
+
+    </Layout>
+
+
+  );
+};
+
+
+
+
+export default Licensing;


### PR DESCRIPTION
Hey @Ajay-Dhangar ,
issue closes #2116 

I wanted to discuss the recent issue I resolved regarding adding the Licensing page with the MIT License to the website's footer.

#### What I Did ?
- I have added a dedicated "Licensing Page" that reflects the use of the MIT License.
- Also, Added Accessible link to the license section in home page.
- Integrated Footer.

#### Video 
Please take a look at the video below -


https://github.com/CodeHarborHub/codeharborhub.github.io/assets/131389695/a1a2e019-93c9-4ec8-8a85-f73f44b91b53


Also @Ajay-Dhangar, Would it be possible to update the label to level2 (if possible) ?
I believe this adjustment would better reflect the effort applied in resolving the issue.

Looking forward to your feedback on this. Thank you for considering my request.

## Type of PR
- [x] Feature enhancement

## Checklist
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have performed a self-review of my code.
- [x] I have read and followed the Contribution Guidelines.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have followed the code style guidelines of this project.
- [x] I have checked for any existing open issues that my pull request may address.
- [x] I have ensured that my changes do not break any existing functionality.
- [x] Each contributor is allowed to create a maximum of 4 issues per day. This helps us manage and address issues efficiently.
- [x] I have read the resources for guidance listed below.
- [x] I have followed security best practices in my code changes.

## Resources for Guidance
Please read the following resources before submitting your contribution:
- [x] [Code Harbor Hub Community Features](https://www.codeharborhub.live/community/features)
- [x] [Docusaurus Documentation](https://docusaurus.io/docs/create-doc)
