### PR TITLE
'CompanyLink' is defined but never used

### DIFF
--- a/src/components/TeamProfileCards/index.tsx
+++ b/src/components/TeamProfileCards/index.tsx
@@ -14,15 +14,15 @@ function WebsiteLink({ to, children }: { to: string; children?: ReactNode }) {
   );
 }
 
-function CompanyLink({ to, children }: { to: string; children?: ReactNode }) {
-  return (
-    <Link to={to}>
-      {children ?? (
-        <Translate id="team.profile.CompanyLinkLabel">company</Translate>
-      )}
-    </Link>
-  );
-}
+// function CompanyLink({ to, children }: { to: string; children?: ReactNode }) {
+//   return (
+//     <Link to={to}>
+//       {children ?? (
+//         <Translate id="team.profile.CompanyLinkLabel">company</Translate>
+//       )}
+//     </Link>
+//   );
+// }
 
 type ProfileProps = {
   className?: string;


### PR DESCRIPTION
## Description
Unused variables are generally considered a code smell and should be avoided.

Removing unused references - It prevents unused modules from being loaded at runtime, improving performance, and preventing the compiler from loading metadata that will never be used. - It prevents conflicts that may occur when trying to reference another variable.

> **NOTE:** If you have intentionally left a variable unused, we suggest you prefix the variable name with a _ to prevent it from being flagged by DeepSource.

**Bad Practice**

```jsx
import fs from 'fs' // <- unused
import { readFileSync } from 'fs'

const text = readFileSync('declaration_of_independence.txt', 'utf-8')
console.log(text)
```

**Recommended**

```jsx
import { readFileSync } from 'fs'

const text = readFileSync('declaration_of_independence.txt', 'utf-8')
console.log(text)
```