### PR TITLE
Fixed bug: Do not use Array index in keys

### DIFF
--- a/src/components/Lesson/index.tsx
+++ b/src/components/Lesson/index.tsx
@@ -22,7 +22,7 @@ const Lesson: React.FC<LessonProps> = ({ title, tags, description }) => {
       <p className="lesson-description">{description}</p> {/* Description or content of the lesson */}
       <div className="lesson-tags"> {/* Container for tags */}
         {tags.map((tag, index) => (
-          <span key={index} className="lesson-tag">{tag}</span>
+          <span key={`${tag}-${index}`} className="lesson-tag">{tag}</span>
         ))
         }
       </div>

--- a/src/components/Lesson/index.tsx
+++ b/src/components/Lesson/index.tsx
@@ -21,8 +21,8 @@ const Lesson: React.FC<LessonProps> = ({ title, tags, description }) => {
       <h2 className="lesson-title">{title}</h2> {/* Title of the lesson */}
       <p className="lesson-description">{description}</p> {/* Description or content of the lesson */}
       <div className="lesson-tags"> {/* Container for tags */}
-        {tags.map((tag, index) => (
-          <span key={`${tag}-${index}`} className="lesson-tag">{tag}</span>
+        {tags.map((tag) => (
+          <span key={tag} className="lesson-tag">{tag}</span>
         ))
         }
       </div>


### PR DESCRIPTION
To avoid using the array index as a key, you can use a unique value from the `tag` array. Here is a revised version of the relevant code snippet:

```tsx
<span key={tag} className="lesson-tag">{tag}</span>
```

This ensures that each `span` element has a unique key, which is important for React's rendering logic.