### PR TITLE
Potential fix for code scanning alert no. 1818: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,5 +1,8 @@
 name: Test deployment
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1818](https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1818)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions in this workflow to the minimum required. Since this job only checks out code and runs Node-based build commands, it only needs read access to repository contents; it does not appear to need write access to any scopes.

The best fix is to add a `permissions` block at the workflow (root) level so it applies to all jobs, including `test-deploy`. This should be placed near the top of `.github/workflows/test-deploy.yml`, alongside `name` and `on`. Specifically, add:

```yaml
permissions:
  contents: read
```

between the `name: Test deployment` line and the `on:` block. No imports or other definitions are needed, and no existing job steps need to change. This will ensure that, even if the repository default is read-write, this workflow’s `GITHUB_TOKEN` is limited to read-only access to repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
