### PR TITLE
Potential fix for code scanning alert no. 1820: Code injection

### DIFF
--- a/.github/workflows/issue_creation_workflow.yml
+++ b/.github/workflows/issue_creation_workflow.yml
@@ -41,8 +41,10 @@ jobs:
           fi
 
       - name: Check for Security and Trust
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          issue_body="${{ github.event.issue.body }}"
+          issue_body="$ISSUE_BODY"
           if [[ "$issue_body" != *"security"* ]] || [[ "$issue_body" != *"trust"* ]]; then
             echo "Issue does not mention security or trust."
             exit 1


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1820](https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1820)

In general, to fix this class of problems in GitHub Actions, we must not interpolate untrusted `${{ ... }}` expressions directly into `run:` shell code. Instead, we pass untrusted values into environment variables using `${{ ... }}` once, and then reference them using the shell’s native variable expansion (`$VAR`) inside the script. This prevents the shell from re‑parsing the raw GitHub expression output as part of the script, because the value is available only at runtime as simple data.

For this specific workflow, we should change the “Check for Security and Trust” step so that:
- The issue body is passed in via `env: ISSUE_BODY: ${{ github.event.issue.body }}`.
- The `run:` script uses `issue_body="$ISSUE_BODY"` instead of embedding `${{ github.event.issue.body }}` directly.

This preserves the existing logic (checking that the body mentions both “security” and “trust”) while ensuring the issue body is treated as data. No other steps in the provided snippet interpolate `github.event.issue.body` inside `run:`, so we only need to modify lines 43–49. No new external libraries are required; we only adjust YAML and shell variable usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
