### PR TITLE
Potential fix for code scanning alert no. 1817: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_creation_workflow.yml
+++ b/.github/workflows/pr_creation_workflow.yml
@@ -1,5 +1,9 @@
 name: PR Creation Workflow
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   pull_request:
     types: [opened, edited]


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1817](https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1817)

To fix the problem, add an explicit `permissions:` block that grants only the minimal read permissions needed for this workflow. Since the workflow only reads pull request data and uses the REST API to read contributors and open issues, it does not require any write permission. The safest general fix is to specify read‑only `contents` and `pull-requests` (and optionally `issues`) permissions, either at the workflow root or for the specific job.

The single best fix with minimal functional impact is to add a root‑level `permissions:` block just below the `name:` line in `.github/workflows/pr_creation_workflow.yml`. This will apply to all jobs in the workflow (currently just `check-pr`). Based on the current steps, the token only needs to read repository data and PR metadata, so:

```yaml
permissions:
  contents: read
  pull-requests: read
```

is sufficient; if you want to be generous for future checks that might read issues directly, you can add `issues: read` as well. No other code changes or imports are needed because we are only constraining the automatically provided `GITHUB_TOKEN` permissions, not changing how it is referenced.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
