### PR TITLE
Potential fix for code scanning alert no. 1816: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1816](https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1816)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions for the `build` job instead of relying on inherited defaults. Since `build` only checks out the code, installs dependencies, and runs tests, it should need at most read access to repository contents. We can therefore set `permissions: contents: read` on the `build` job.

Concretely, in `.github/workflows/release-package.yml`, add a `permissions` block under `jobs.build`, at the same indentation level as `runs-on`. This will mirror the existing pattern used by `publish-gpr` but with narrower access. No other steps or jobs need to change, and no additional imports or methods are required because this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
