### PR TITLE
Potential fix for code scanning alert no. 1815: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue_creation_workflow.yml
+++ b/.github/workflows/issue_creation_workflow.yml
@@ -1,5 +1,9 @@
 name: Issue Creation Workflow
 
+permissions:
+  contents: read
+  issues: read
+
 on:
   issues:
     types: [opened]


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1815](https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1815)

In general, this issue is fixed by explicitly specifying a `permissions` block at the workflow root (or per job) to restrict the automatically provided `GITHUB_TOKEN` to the minimal scopes required. This prevents GitHub from falling back to potentially broad default permissions.

For this specific workflow, the job only reads issue information via the REST API using `secrets.GITHUB_TOKEN`. It does not modify repository contents, issues, or pull requests. Therefore, we can safely set `contents: read` and `issues: read` at the workflow level. Placing the `permissions` block at the top (next to `name` and `on`) will apply it to all jobs without changing behavior.

Concretely, in `.github/workflows/issue_creation_workflow.yml`, add:

```yaml
permissions:
  contents: read
  issues: read
```

right after the `name: Issue Creation Workflow` line and before the `on:` block. No additional imports, methods, or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
