### PR TITLE
Potential fix for code scanning alert no. 1811: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/close-old-issue.yml
+++ b/.github/workflows/close-old-issue.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   close-issues:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1811](https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1811)

To fix the problem, declare explicit `permissions` for the workflow so that the `GITHUB_TOKEN` is limited to what the job actually needs. This workflow reads open issues and then closes some of them and posts comments, so it requires `issues: write`. It does not need to modify repository contents, workflows, or other resources, so other permissions can remain at their default of `none`. The cleanest approach is to add a `permissions` block at the job level (`close-issues`), right under `runs-on: ubuntu-latest`, so the scope applies only to this job.

Concretely, edit `.github/workflows/close-old-issue.yml` and, beneath `runs-on: ubuntu-latest`, insert:

```yaml
    permissions:
      issues: write
```

This preserves all existing behavior (the API calls will continue to work) while constraining the token to the minimum required privilege. No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
