### PR TITLE
Potential fix for code scanning alert no. 1812: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-content-on-labels.yml
+++ b/.github/workflows/auto-content-on-labels.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   addContent:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1812](https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1812)

In general, the fix is to add an explicit `permissions` block to the workflow, limiting `GITHUB_TOKEN` to the least privileges needed. For this job, the script reads event/label data and creates a comment on an issue or pull request. It does not modify repository contents, so `contents` can safely be `read`. To create comments on both issues and pull requests triggered by `issues` and `pull_request` events, we should grant `issues: write` and `pull-requests: write`. The cleanest approach is to add a workflow-level `permissions` block near the top so it applies to all jobs (there is only one job) without changing any other behavior.

Concretely, in `.github/workflows/auto-content-on-labels.yml`, insert:

```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```

between the `on:` block and the `jobs:` block. No imports or additional methods are required; this is purely a YAML configuration change. Existing steps, including `actions/github-script@v7` and usage of `${{ secrets.GITHUB_TOKEN }}`, remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
