### PR TITLE
Potential fix for code scanning alert no. 1813: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     name: Build CodeHarborHub
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1813](https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1813)

To fix the problem, explicitly define a least-privilege `permissions` block for the `build` job (or at the workflow root) so it does not inherit broad repository defaults. The `build` job checks out the code, installs dependencies, builds, and uploads a Pages artifact; this only requires read access to repository contents and the ability to upload the artifact. The upload-pages-artifact action does not require extra repo write permissions; current GitHub docs recommend `contents: read` for the build job.

The best minimal fix without changing functionality is:
- Add `permissions: contents: read` to the `build` job.
- Leave the existing `permissions` block on the `deploy` job unchanged, since it is already least-privilege for Pages deployment (`pages: write`, `id-token: write`).

Concretely:
- In `.github/workflows/deploy.yml`, under `jobs: build:`, insert a `permissions:` section before `runs-on: ubuntu-latest`:
  ```yaml
  permissions:
    contents: read
  ```
No other imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
