### PR TITLE
Potential fix for code scanning alert no. 1814: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,6 @@
 name: Docker Image CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1814](https://github.com/codeharborhub/codeharborhub.github.io/security/code-scanning/1814)

To fix this, explicitly declare minimal GITHUB_TOKEN permissions in the workflow. Since the job checks out the code and builds a Docker image locally, it only needs read access to the repository contents. We can add a top-level `permissions` block (applies to all jobs unless overridden) with `contents: read`. This does not change the functional behavior of the workflow but ensures the token cannot perform write operations.

Concretely, in `.github/workflows/docker-image.yml`, insert:

```yaml
permissions:
  contents: read
```

right after the `name: Docker Image CI` line (line 1) and before the `on:` section (line 3). No additional imports or methods are needed; this is purely a YAML configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
